### PR TITLE
Add jms message properties to receiver

### DIFF
--- a/src/main/java/com/kjetland/dropwizard/activemq/ActiveMQBaseReceiver.java
+++ b/src/main/java/com/kjetland/dropwizard/activemq/ActiveMQBaseReceiver.java
@@ -1,0 +1,8 @@
+package com.kjetland.dropwizard.activemq;
+
+import java.util.Properties;
+
+public interface ActiveMQBaseReceiver<T> {
+
+    void receive(T message, Properties messageProperties);
+}

--- a/src/main/java/com/kjetland/dropwizard/activemq/ActiveMQBundle.java
+++ b/src/main/java/com/kjetland/dropwizard/activemq/ActiveMQBundle.java
@@ -120,10 +120,10 @@ public class ActiveMQBundle implements ConfiguredBundle<ActiveMQConfigHolder>, M
     }
 
     // This must be used during run-phase
-    public <T> void registerReceiver(String destination, ActiveMQReceiver<T> receiver, Class<? extends T> clazz,
+    public <T> void registerReceiver(String destination, ActiveMQBaseReceiver<T> receiver, Class<? extends T> clazz,
                                      final boolean ackMessageOnException) {
 
-        ActiveMQReceiverHandler<T> handler = new ActiveMQReceiverHandler<>(
+        ActiveMQReceiverHandler<T> handler = new ActiveMQReceiverHandler<T>(
                 destination,
                 connectionFactory,
                 receiver,
@@ -150,10 +150,10 @@ public class ActiveMQBundle implements ConfiguredBundle<ActiveMQConfigHolder>, M
     }
 
     // This must be used during run-phase
-    public <T> void registerReceiver(String destination, ActiveMQReceiver<T> receiver, Class<? extends T> clazz,
+    public <T> void registerReceiver(String destination, ActiveMQBaseReceiver<T> receiver, Class<? extends T> clazz,
                                      ActiveMQBaseExceptionHandler exceptionHandler) {
 
-        ActiveMQReceiverHandler<T> handler = new ActiveMQReceiverHandler<>(
+        ActiveMQReceiverHandler<T> handler = new ActiveMQReceiverHandler<T>(
                 destination,
                 connectionFactory,
                 receiver,
@@ -166,7 +166,7 @@ public class ActiveMQBundle implements ConfiguredBundle<ActiveMQConfigHolder>, M
     }
 
     // This must be used during run-phase
-    public <T> void registerReceiver(String destination, ActiveMQReceiver<T> receiver, Class<? extends T> clazz,
+    public <T> void registerReceiver(String destination, ActiveMQBaseReceiver<T> receiver, Class<? extends T> clazz,
                                      ActiveMQExceptionHandler exceptionHandler) {
         registerReceiver(destination, receiver, clazz, (ActiveMQBaseExceptionHandler) exceptionHandler);
     }

--- a/src/main/java/com/kjetland/dropwizard/activemq/ActiveMQReceiver.java
+++ b/src/main/java/com/kjetland/dropwizard/activemq/ActiveMQReceiver.java
@@ -1,6 +1,13 @@
 package com.kjetland.dropwizard.activemq;
 
-public interface ActiveMQReceiver<T> {
+import java.util.Properties;
 
-    public void receive(T message);
+public interface ActiveMQReceiver<T> extends ActiveMQBaseReceiver<T> {
+
+    @Override
+    default void receive(T message, Properties messageProperties) {
+        receive(message);
+    }
+
+    void receive(T message);
 }

--- a/src/test/java/com/kjetland/dropwizard/activemq/ActiveMQReceiverHandlerReliveryTest.java
+++ b/src/test/java/com/kjetland/dropwizard/activemq/ActiveMQReceiverHandlerReliveryTest.java
@@ -9,6 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Optional;
+import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 
@@ -75,10 +76,10 @@ public class ActiveMQReceiverHandlerReliveryTest {
 
         ObjectMapper objectMapper = new ObjectMapper();
 
-        ActiveMQReceiverHandler<String> h = new ActiveMQReceiverHandler<>(
+        ActiveMQReceiverHandler<String> h = new ActiveMQReceiverHandler<String>(
                 destinationName,
                 connectionFactory,
-                (m)->receiveMessage(m),
+                (m,p)->receiveMessage(m),
                 String.class,
                 objectMapper,
                 (m,e) -> exceptionHandler(m,e),

--- a/src/test/java/com/kjetland/dropwizard/activemq/ActiveMQReceiverHandlerTest.java
+++ b/src/test/java/com/kjetland/dropwizard/activemq/ActiveMQReceiverHandlerTest.java
@@ -117,6 +117,8 @@ public class ActiveMQReceiverHandlerTest {
 
 
         TextMessage msg = mock(TextMessage.class);
+        Enumeration enumeration = mock(Enumeration.class);
+        when(msg.getPropertyNames()).thenReturn(enumeration);
         when(msg.getText()).thenReturn(m);
         return msg;
     }
@@ -130,10 +132,10 @@ public class ActiveMQReceiverHandlerTest {
     @Test
     public void testNormal() throws Exception {
         setUpMocks(Arrays.asList(null, "a", "b", null, "d"));
-        ActiveMQReceiverHandler<String> h = new ActiveMQReceiverHandler<>(
+        ActiveMQReceiverHandler<String> h = new ActiveMQReceiverHandler<String>(
                 destinationName,
                 connectionFactory,
-                (m)->receiveMessage((String)m),
+                (m,p)->receiveMessage((String)m),
                 String.class,
                 objectMapper,
                 (m,e) -> exceptionHandler(m,e),
@@ -155,10 +157,10 @@ public class ActiveMQReceiverHandlerTest {
     @Test
     public void testExceptionInReceiver() throws Exception {
         setUpMocks(Arrays.asList(null, "a", THROW_EXCEPTION_IN_RECEIVER, "b", null, "d"));
-        ActiveMQReceiverHandler<String> h = new ActiveMQReceiverHandler<>(
+        ActiveMQReceiverHandler<String> h = new ActiveMQReceiverHandler<String>(
                 destinationName,
                 connectionFactory,
-                (m)->receiveMessage((String)m),
+                (m,p)->receiveMessage((String)m),
                 String.class,
                 objectMapper,
                 (m,e) -> exceptionHandler(m,e),
@@ -181,10 +183,10 @@ public class ActiveMQReceiverHandlerTest {
     public void testExceptionInMessageConsumer() throws Exception {
 
         setUpMocks(Arrays.asList(null, "a", THROW_EXCEPTION_IN_CONSUMER, "b", null, "d"));
-        ActiveMQReceiverHandler<String> h = new ActiveMQReceiverHandler<>(
+        ActiveMQReceiverHandler<String> h = new ActiveMQReceiverHandler<String>(
                 destinationName,
                 connectionFactory,
-                (m)->receiveMessage(m),
+                (m,p)->receiveMessage(m),
                 String.class,
                 objectMapper,
                 (m,e) -> exceptionHandler(m,e),
@@ -208,10 +210,10 @@ public class ActiveMQReceiverHandlerTest {
 
         setUpMocks(Arrays.asList(null, "a", THROW_EXCEPTION_IN_CONSUMER_CLOSED, "b", null, "d",
                 THROW_EXCEPTION_IN_CONSUMER_CLOSED, THROW_EXCEPTION_IN_CONSUMER_CLOSED));
-        ActiveMQReceiverHandler<String> h = new ActiveMQReceiverHandler<>(
+        ActiveMQReceiverHandler<String> h = new ActiveMQReceiverHandler<String>(
                 destinationName,
                 connectionFactory,
-                (m)->receiveMessage(m),
+                (m,p)->receiveMessage(m),
                 String.class,
                 objectMapper,
                 (m,e) -> exceptionHandler(m, e),


### PR DESCRIPTION
In some cases I need to get properties from JMS Message, but the current version does not allow that. I've created a new interface, ActiveMQBaseReceiver. 
```java
    void receive(T message, Properties messageProperties);
```

ActiveMQBaseReceiver replaces ActiveMQReceiver, but ActiveMQReceiver remains in order to be backward compatible. 
```java
    @Override
    default void receive(T message, Properties messageProperties) {
        receive(message);
    }

    void receive(T message);
```