### PR TITLE
Add support for secure brokers

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,9 @@ activeMQ:
 ```yaml
 
 activeMQ:
-  brokerUrl: failover:(tcp://boker1.com:61616,tcp://broker2.com:61616)?randomize=false
+  brokerUrl: failover:(tcp://broker1.com:61616,tcp://broker2.com:61616)?randomize=false
+  # brokerUsername: username
+  # brokerPassword: password
   # shutdownWaitInSeconds: 20
   # healthCheckMillisecondsToWait: 2000
   # timeToLiveInSeconds: -1     (Default message time-to-live is off. Specify a maximum lifespan here in seconds for all messages.)
@@ -255,3 +257,7 @@ activeMQBundle.registerReceiver(
     });
 ```
 
+Connecting to secure brokers
+----------------------------
+
+Connecting to a secure broker is possible by setting both the username (brokerUsername) and password (brokerPassword) in an application's config file.

--- a/src/main/java/com/kjetland/dropwizard/activemq/ActiveMQBundle.java
+++ b/src/main/java/com/kjetland/dropwizard/activemq/ActiveMQBundle.java
@@ -32,6 +32,8 @@ public class ActiveMQBundle implements ConfiguredBundle<ActiveMQConfigHolder>, M
         this.environment = environment;
         final String brokerUrl = configuration.getActiveMQ().brokerUrl;
         final int configuredTTL = configuration.getActiveMQ().timeToLiveInSeconds;
+        final Optional<String> username = Optional.ofNullable(configuration.getActiveMQ().brokerUsername);
+        final Optional<String> password = Optional.ofNullable(configuration.getActiveMQ().brokerPassword);
         defaultTimeToLiveInSeconds = Optional.ofNullable(configuredTTL > 0 ? configuredTTL : null);
 
         log.info("Setting up activeMq with brokerUrl {}", brokerUrl);
@@ -39,6 +41,10 @@ public class ActiveMQBundle implements ConfiguredBundle<ActiveMQConfigHolder>, M
         log.debug("All activeMQ config: " + configuration.getActiveMQ());
 
         realConnectionFactory = new ActiveMQConnectionFactory(brokerUrl);
+        if (username.isPresent() && password.isPresent()) {
+            realConnectionFactory.setUserName(username.get());
+            realConnectionFactory.setPassword(password.get());
+        }
         connectionFactory = new PooledConnectionFactory();
         connectionFactory.setConnectionFactory(realConnectionFactory);
 

--- a/src/main/java/com/kjetland/dropwizard/activemq/ActiveMQConfig.java
+++ b/src/main/java/com/kjetland/dropwizard/activemq/ActiveMQConfig.java
@@ -12,6 +12,12 @@ public class ActiveMQConfig {
     public String brokerUrl;
 
     @JsonProperty
+    public String brokerUsername;
+
+    @JsonProperty
+    public String brokerPassword;
+
+    @JsonProperty
     public long healthCheckMillisecondsToWait = 2000; // 2 seconds
 
     @JsonProperty
@@ -31,6 +37,8 @@ public class ActiveMQConfig {
                 ", healthCheckMillisecondsToWait=" + healthCheckMillisecondsToWait +
                 ", shutdownWaitInSeconds=" + shutdownWaitInSeconds +
                 ", timeToLiveInSeconds=" + timeToLiveInSeconds +
+                ", brokerUsername=" + brokerUsername +
+                ", brokerPassword=" + brokerPassword +
                 ", pool=" + pool +
                 '}';
     }


### PR DESCRIPTION
For secure brokers that require a username and password to connect the username and password need to be set on the AMQ connection. Add configuration parameters for the username and password, and if both are present set them on the AMQ connection before starting the pool.

New Configuation properties under AMQ:
brokerUsername - user to authenticate to the broker
brokerPassword - password to use with user when authenticating to the broker