### PR TITLE
Support for receiving plain java objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ activeMQ:
   # shutdownWaitInSeconds: 20
   # healthCheckMillisecondsToWait: 2000
   # timeToLiveInSeconds: -1     (Default message time-to-live is off. Specify a maximum lifespan here in seconds for all messages.)
+  # trustedPackages: (To prevent malicious code from being deserialized. Needed if you want to receive plain object messages, see http://activemq.apache.org/objectmessage.html)
+  #   - com.some.package
+  #   - java.util
+
   pool:
     maxConnections: 1
     maximumActiveSessionPerConnection: 3
@@ -328,3 +332,22 @@ activeMQConnections:
   gbQueue:
       brokerUrl: tcp://localhost:61626
 ```
+
+Receiving object messages
+-------------------------
+The bundle also supports receiving plain object messages. The code required for receiving object messages is the same as 
+for json deserialized objects. The magic is happening internally in the library before the message is dispatched to the 
+receiver.
+
+To avoid malicious code from being deserialized, you must configure trusted packages in the bundle configuration, i.e.
+the packages containing the code you want to receive. More information can be found at 
+http://activemq.apache.org/objectmessage.html . Default behaviour is to reject all packages.
+
+```yaml
+activeMQ:
+  ...
+  trustedPackages:
+    - com.youpackages.*
+    - java.util
+```
+

--- a/src/main/java/com/kjetland/dropwizard/activemq/ActiveMQBundle.java
+++ b/src/main/java/com/kjetland/dropwizard/activemq/ActiveMQBundle.java
@@ -51,6 +51,7 @@ public class ActiveMQBundle implements ConfiguredBundle<ActiveMQConfigHolder>, M
         log.debug("All activeMQ config: " + activeMQConfig);
 
         realConnectionFactory = new ActiveMQConnectionFactory(brokerUrl);
+        realConnectionFactory.setTrustedPackages(activeMQConfig.trustedPackages);
         if (username.isPresent() && password.isPresent()) {
             realConnectionFactory.setUserName(username.get());
             realConnectionFactory.setPassword(password.get());

--- a/src/main/java/com/kjetland/dropwizard/activemq/ActiveMQConfig.java
+++ b/src/main/java/com/kjetland/dropwizard/activemq/ActiveMQConfig.java
@@ -4,6 +4,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.joining;
 
 public class ActiveMQConfig {
 
@@ -28,6 +33,10 @@ public class ActiveMQConfig {
 
     @JsonProperty
     @Valid
+    public List<String> trustedPackages = new ArrayList<>();
+
+    @JsonProperty
+    @Valid
     public ActiveMQPoolConfig pool;
 
     @Override
@@ -39,6 +48,7 @@ public class ActiveMQConfig {
                 ", timeToLiveInSeconds=" + timeToLiveInSeconds +
                 ", brokerUsername=" + brokerUsername +
                 ", brokerPassword=" + brokerPassword +
+                ", trustedPackages=" + trustedPackages.stream().collect(joining(", ")) +
                 ", pool=" + pool +
                 '}';
     }


### PR DESCRIPTION
We are using this excellent bundle in one of our projects. Our code is connecting to a legacy system using JMS on activemq and need to be able to receive ObjectMessages.

This PR adds support for receiving serialized java objects without doing any json deserialization.